### PR TITLE
Change which Qt libraries we link with so that we use the ones that s…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,12 @@ if (IDA_VERSION LESS 690)
     target_link_libraries(${CMAKE_PROJECT_NAME} Qt4::QtCore Qt4::QtGui)
 else ()
     target_link_libraries(${CMAKE_PROJECT_NAME} Qt5::Widgets)
+    # On macs, we need to link to the frameworks in the IDA application folder
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        set_target_properties(Qt5::Widgets PROPERTIES IMPORTED_LOCATION_RELEASE "${IDA_INSTALL_DIR}/idaq.app/Contents/Frameworks/QtWidgets.framework/QtWidgets")
+        set_target_properties(Qt5::Gui PROPERTIES IMPORTED_LOCATION_RELEASE "${IDA_INSTALL_DIR}/idaq.app/Contents/Frameworks/QtGui.framework/QtGui")
+        set_target_properties(Qt5::Core PROPERTIES IMPORTED_LOCATION_RELEASE "${IDA_INSTALL_DIR}/idaq.app/Contents/Frameworks/QtCore.framework/QtCore")        
+    endif ()
 endif ()
 
 install(DIRECTORY skin/ DESTINATION skin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,9 @@ else ()
     target_link_libraries(${CMAKE_PROJECT_NAME} Qt5::Widgets)
     # On macs, we need to link to the frameworks in the IDA application folder
     if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-        set_target_properties(Qt5::Widgets PROPERTIES IMPORTED_LOCATION_RELEASE "${IDA_INSTALL_DIR}/idaq.app/Contents/Frameworks/QtWidgets.framework/QtWidgets")
-        set_target_properties(Qt5::Gui PROPERTIES IMPORTED_LOCATION_RELEASE "${IDA_INSTALL_DIR}/idaq.app/Contents/Frameworks/QtGui.framework/QtGui")
-        set_target_properties(Qt5::Core PROPERTIES IMPORTED_LOCATION_RELEASE "${IDA_INSTALL_DIR}/idaq.app/Contents/Frameworks/QtCore.framework/QtCore")        
+        foreach (qtlib Widgets;Gui;Core)
+            set_target_properties(Qt5::${qtlib} PROPERTIES IMPORTED_LOCATION_RELEASE "${IDA_Qt${qtlib}_LIBRARY}")
+        endforeach()
     endif ()
 endif ()
 

--- a/cmake/IDA.cmake
+++ b/cmake/IDA.cmake
@@ -149,6 +149,21 @@ elseif (UNIX)
         find_library(IDA_IDA_LIBRARY NAMES "ida" PATHS ${IDA_INSTALL_DIR} REQUIRED)
     endif ()
     list(APPEND ida_libraries ${IDA_IDA_LIBRARY})
+
+    # On macOS, we can look up the path of each Qt library inside the IDA installation.
+    # It might be possible to get this to work also on linux by parameterizing the file suffix.
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        foreach(qtlib Gui;Core;Widgets)
+            file(GLOB_RECURSE qtlibpaths "${IDA_INSTALL_DIR}/Qt${qtlib}")
+            # Typically we will find exactly 2 paths to the libfile on macOS because of 
+            # how the framework versioning works. Either one is fine, so pick the first.
+            foreach(p ${qtlibpaths})
+                set(IDA_Qt${qtlib}_LIBRARY ${p} CACHE FILEPATH "Path to IDA's Qt${qtlib}")
+                break()
+            endforeach()
+        endforeach()
+    endif()
+    
 endif ()
 
 set(ida_libraries ${ida_libraries} CACHE INTERNAL "IDA libraries" FORCE)


### PR DESCRIPTION
…hip with IDA

This is not polished by any means, but it *does* make it build, at least with `--skip-install`. It's not entirely clear to me how `IDA_INSTALL_DIR`  is used by the `install` action. It would probably be much cleaner to use some `find_` action starting from the root and figure out where the `Qt` libs are and where the `plugins` directory is.

When I verified the build, I used `--idaq-path /Applications/IDA Pro 6.95/`.