### PR TITLE
Linux build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,8 @@ if (IDA_VERSION LESS 690)
     target_link_libraries(${CMAKE_PROJECT_NAME} Qt4::QtCore Qt4::QtGui)
 else ()
     target_link_libraries(${CMAKE_PROJECT_NAME} Qt5::Widgets)
-    # On macs, we need to link to the frameworks in the IDA application folder
-    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # On macs/linux, we need to link to the frameworks in the IDA application folder
+    if ((${CMAKE_SYSTEM_NAME} MATCHES "Darwin") OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
         foreach (qtlib Widgets;Gui;Core)
             set_target_properties(Qt5::${qtlib} PROPERTIES IMPORTED_LOCATION_RELEASE "${IDA_Qt${qtlib}_LIBRARY}")
         endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,8 @@ if (IDA_VERSION LESS 690)
     target_link_libraries(${CMAKE_PROJECT_NAME} Qt4::QtCore Qt4::QtGui)
 else ()
     target_link_libraries(${CMAKE_PROJECT_NAME} Qt5::Widgets)
-    # On macs/linux, we need to link to the frameworks in the IDA application folder
+    # On macs, we need to link to the frameworks in the IDA application folder
+    # On Linux, we need to link to the specific libs in the IDA dir
     if ((${CMAKE_SYSTEM_NAME} MATCHES "Darwin") OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
         foreach (qtlib Widgets;Gui;Core)
             set_target_properties(Qt5::${qtlib} PROPERTIES IMPORTED_LOCATION_RELEASE "${IDA_Qt${qtlib}_LIBRARY}")

--- a/cmake/IDA.cmake
+++ b/cmake/IDA.cmake
@@ -151,7 +151,6 @@ elseif (UNIX)
     list(APPEND ida_libraries ${IDA_IDA_LIBRARY})
 
     # On macOS, we can look up the path of each Qt library inside the IDA installation.
-    # It might be possible to get this to work also on linux by parameterizing the file suffix.
     if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         foreach(qtlib Gui;Core;Widgets)
             file(GLOB_RECURSE qtlibpaths "${IDA_INSTALL_DIR}/../Frameworks/Qt${qtlib}")
@@ -161,9 +160,11 @@ elseif (UNIX)
                 set(IDA_Qt${qtlib}_LIBRARY ${p} CACHE FILEPATH "Path to IDA's Qt${qtlib}")
                 break()
             endforeach()
+    elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        foreach(qtlib Gui;Core;Widgets)
+            set(IDA_Qt${qtlib}_LIBRARY ${IDA_INSTALL_DIR}/libQt5${qtlib}.so.5 CACHE FILEPATH "Path to IDA's Qt${qtlib}")
         endforeach()
     endif()
-    
 endif ()
 
 set(ida_libraries ${ida_libraries} CACHE INTERNAL "IDA libraries" FORCE)


### PR DESCRIPTION
Only tested on 6.95 as it's the only version I have available atm. Build is successful and can confirm the plugin works with idaq and idaq64.