### PR TITLE
Add color theme selection box

### DIFF
--- a/skin/adwaita-dark/adwaita-dark.clr
+++ b/skin/adwaita-dark/adwaita-dark.clr
@@ -1,0 +1,114 @@
+[DISASM]
+000000	 //
+ff0000	 //Default color
+a46534	 //Regular comment
+808080	 //Repeatable comment
+808080	 //Automatic comment
+36342e	 //Instruction
+800000	 //Dummy Data Name
+a46534	 //Regular Data Name
+a46534	 //Demangled Name
+800000	 //Punctuation
+069a4e	 //Char constant in instruction
+00ff00	 //String constant in instruction
+069a4e	 //Numeric constant in instruction
+2929ef	 //Void operand
+069a4e	 //Code reference
+ff8080	 //Data reference
+0000ff	 //Code reference to tail byte
+008080	 //Data reference to tail byte
+010101	 //Error or problem
+c0c0c0	 //Line prefix
+a46534	 //Binary line prefix bytes
+a46534	 //Extra line
+ff0000	 //Alternative operand
+808080	 //Hidden name
+ff8080	 //Library function name
+008000	 //Local variable name
+800000	 //Dummy code name
+a46534	 //Assembler directive
+800080	 //Macro
+069a4e	 //String constant in data directive
+008000	 //Char constant in data directive
+069a4e	 //Numeric constant in data directive
+800000	 //Keywords
+800000	 //Register name
+2929ef	 //Imported name
+008080	 //Segment name
+800000	 //Dummy unknown name
+cf9f72	 //Regular code name
+800000	 //Regular unknown name
+a46534	 //Collapsed line
+000000	 //Max color number
+cfd7d3	 //Line prefix: library function
+eceeee	 //Line prefix: regular function
+ffff00	 //Line prefix: instruction
+000000	 //Line prefix: data
+000080	 //Line prefix: unexplored
+808080	 //Line prefix: externs
+008080	 //Line prefix: current item
+2929ef	 //Line prefix: current line
+000000	 //Punctuation
+ff0000	 //Opcode bytes
+000000	 //Manual operand
+[NAVBAR]
+ffffaa	 //Library function
+e8a200	 //Regular function
+577ab9	 //Instruction
+c0c0c0	 //Data item
+6bb6b6	 //Unexplored
+ffa6ff	 //External symbol
+5b5bff	 //Errors
+000000	 //Gaps
+7fffff	 //Cursor
+00aaff	 //Address
+[DEBUG]
+ffd060	 //Current IP
+ffa0a0	 //Current IP (Enabled)
+408020	 //Current IP (Disabled)
+ffffcc	 //Current IP (Unavailible)
+0000ff	 //Address
+00ff00	 //Address (Enabled)
+004080	 //Address (Disabled)
+0080ff	 //Address (Unavailible)
+000000	 //Registers
+ff0000	 //Registers (Changed)
+800080	 //Registers (Edited)
+[ARROW]
+c0c0c0	 //Jump in current function
+0000ff	 //Jump external to function
+000000	 //Jump under the cursor
+008000	 //Jump target
+ff4040	 //Register target
+[GRAPH]
+292723	 //Top color
+292723	 //Bottom color
+535755	 //Normal title
+9c5d21	 //Selected title
+9c5d21	 //Current title
+00ffff	 //Group frame
+000000	 //Node shadow
+ffffcc	 //Highlight color 1
+ccffcc	 //Highlight color 2
+0000ff	 //Foreign node
+ff0000	 //Normal edge
+008000	 //Yes edge
+0000ff	 //No edge
+ff00ff	 //Highlighted edge
+ffff00	 //Current edge
+[MISC]
+eceeee	 //Message text
+ffffff	 //Message background
+404080	 //Patched bytes
+0080ff	 //Unsaved changes
+[OTHER]
+4fe9fc	 //Highlight color
+eceeee	 //Hint color
+[SYNTAX]
+cf9f72	1	0	 //Keyword 1
+cf9f72	1	0	 //Keyword 2
+0000cc	1	0	 //Keyword 3
+2929ef	0	0	 //String
+069a4e	1	1	 //Comment
+cf9f72	1	0	 //Preprocessor
+8b8b00	1	0	 //Number

--- a/skin/ida-default/ida-default.clr
+++ b/skin/ida-default/ida-default.clr
@@ -1,0 +1,114 @@
+[DISASM]
+000000	 //
+ff0000	 //Default color
+ff0000	 //Regular comment
+808080	 //Repeatable comment
+808080	 //Automatic comment
+800000	 //Instruction
+800000	 //Dummy Data Name
+ff0000	 //Regular Data Name
+ff0000	 //Demangled Name
+800000	 //Punctuation
+008000	 //Char constant in instruction
+00ff00	 //String constant in instruction
+008000	 //Numeric constant in instruction
+0080ff	 //Void operand
+008000	 //Code reference
+ff8080	 //Data reference
+0000ff	 //Code reference to tail byte
+008080	 //Data reference to tail byte
+010101	 //Error or problem
+c0c0c0	 //Line prefix
+ff0000	 //Binary line prefix bytes
+ff0000	 //Extra line
+ff0000	 //Alternative operand
+808080	 //Hidden name
+ff8080	 //Library function name
+008000	 //Local variable name
+800000	 //Dummy code name
+ff0000	 //Assembler directive
+800080	 //Macro
+008000	 //String constant in data directive
+008000	 //Char constant in data directive
+408000	 //Numeric constant in data directive
+800000	 //Keywords
+800000	 //Register name
+ff00ff	 //Imported name
+008080	 //Segment name
+800000	 //Dummy unknown name
+ff0000	 //Regular code name
+800000	 //Regular unknown name
+ff0000	 //Collapsed line
+000000	 //Max color number
+ffffff	 //Line prefix: library function
+afbbc0	 //Line prefix: regular function
+ffff00	 //Line prefix: instruction
+000000	 //Line prefix: data
+000080	 //Line prefix: unexplored
+808080	 //Line prefix: externs
+008080	 //Line prefix: current item
+ff00ff	 //Line prefix: current line
+000000	 //Punctuation
+ff0000	 //Opcode bytes
+000000	 //Manual operand
+[NAVBAR]
+ffffaa	 //Library function
+e8a200	 //Regular function
+577ab9	 //Instruction
+c0c0c0	 //Data item
+6bb6b6	 //Unexplored
+ffa6ff	 //External symbol
+5b5bff	 //Errors
+000000	 //Gaps
+7fffff	 //Cursor
+00aaff	 //Address
+[DEBUG]
+ffd060	 //Current IP
+ffa0a0	 //Current IP (+ enabled breakpoint)
+408020	 //Current IP (+ disabled breakpoint)
+ffffcc	 //Default background
+0000ff	 //Address (+ enabled breakpoint)
+00ff00	 //Address (+ disabled breakpoint)
+004080	 //Current IP (+ unavailable breakpoint)
+0080ff	 //Address (+ unavailable breakpoint)
+000000	 //Registers
+ff0000	 //Registers (changed)
+800080	 //Registers (edited)
+[ARROW]
+c0c0c0	 //Jump in current function
+0000ff	 //Jump external to function
+000000	 //Jump under the cursor
+008000	 //Jump target
+ff4040	 //Register target
+[GRAPH]
+ffffff	 //Top color
+fff8e0	 //Bottom color
+ffffff	 //Normal title
+f9f9b1	 //Selected title
+cfcfa0	 //Current title
+00ffff	 //Group frame
+000000	 //Node shadow
+ffffcc	 //Highlight color 1
+ccffcc	 //Highlight color 2
+0000ff	 //Foreign node
+ff0000	 //Normal edge
+008000	 //Yes edge
+0000ff	 //No edge
+ff00ff	 //Highlighted edge
+ffff00	 //Current edge
+[MISC]
+000000	 //Message text
+ffffff	 //Message background
+404080	 //Patched bytes
+0080ff	 //Unsaved changes
+[OTHER]
+00ffff	 //Highlight color
+e1ffff	 //Hint color
+[SYNTAX]
+ff0000	0	0	 //Keyword 1
+800080	0	0	 //Keyword 2
+0000ff	0	0	 //Keyword 3
+00008b	0	0	 //String
+006400	0	1	 //Comment
+ff0000	1	0	 //Preprocessor
+8b8b00	1	0	 //Number

--- a/skin/idaskins-dark/ida-consonance.clr
+++ b/skin/idaskins-dark/ida-consonance.clr
@@ -1,0 +1,103 @@
+[DISASM]
+000000	 //Instruction
+aaaaaa	 //Directive
+f3c5ff	 //Macro name
+7e6082	 //Register name
+666666	 //Other keywords
+ffffff	 //Dummy data name
+b9ebeb	 //Dummy code name
+b9ebeb	 //Dummy unexplored name
+bbecff	 //Hidden name
+c0c0c0	 //Library function name
+00d269	 //Local variable name
+00ff00	 //Regular data name
+3250d2	 //Regular code name
+4646ff	 //Regular unexplored name
+7faaff	 //Demangled name
+617c7c	 //Segment name
+3250d2	 //Imported name
+008080	 //Suspicious constant
+3734ff	 //Char in instruction
+c0c0c0	 //String in instruction
+595959	 //Number in instruction
+f3c5ff	 //Char in data
+ffaaff	 //String in data
+00d2ff	 //Number in data
+ffff00	 //Code reference
+0080ff	 //Data reference
+00d2ff	 //Code reference to tail
+00d69d	 //Data reference to tail
+7e07df	 //Automatic comment
+00d269	 //Regular comment
+00f379	 //Repeatable comment
+3250d2	 //Extra line
+ababab	 //Collapsed line
+adad73	 //Line prefix: library function
+fd5aff	 //Line prefix: regular function
+7fffff	 //Line prefix: instruction
+00ffaa	 //Line prefix: data
+00d2ff	 //Line prefix: unexplored
+ffaaff	 //Line prefix: externs
+00ffff	 //Line prefix: current item
+000000	 //Line prefix: current line
+2d2d2d	 //Punctuation
+32ade1	 //Opcode bytes
+ffff00	 //Manual operand
+666666	 //Error
+0000aa	 //Default color
+617c7c	 //Selected
+009d9d	 //Library function
+ff55ff	 //Regular function
+000000	 //Single instruction
+00aaff	 //Data bytes
+000000	 //Unexplored byte
+[NAVBAR]
+ffaa00	 //Library function
+00aaff	 //Regular function
+000080	 //Instruction
+b9ebeb	 //Data item
+007878	 //Unexplored
+ff00ff	 //External symbol
+0000ca	 //Errors
+4a4a4a	 //Gaps
+00ff80	 //Cursor
+0080ff	 //Address
+[DEBUG]
+ffd060	 //Current IP
+ffa0a0	 //Current IP (Enabled)
+408020	 //Current IP (Disabled)
+ffffcc	 //Current IP (Unavailible)
+000076	 //Address
+00ff00	 //Address (Enabled)
+004080	 //Address (Disabled)
+0080ff	 //Address (Unavailible)
+000000	 //Registers
+ff0000	 //Registers (Changed)
+800080	 //Registers (Edited)
+[ARROW]
+34466c	 //Jump in current function
+dede00	 //Jump external to function
+00aaff	 //Jump under the cursor
+008000	 //Jump target
+ff4040	 //Register target
+[GRAPH]
+b2b2b2	 //Top color
+b2b2b2	 //Bottom color
+f5f5f5	 //Normal title
+989faa	 //Selected title
+54585e	 //Current title
+00ffff	 //Group frame
+242424	 //Node shadow
+003900	 //Highlight color 1
+00006d	 //Highlight color 2
+0000ff	 //Foreign node
+cb4300	 //Normal edge
+009100	 //Yes edge
+0000bc	 //No edge
+ffaaaa	 //Highlighted edge
+008ec6	 //Current edge
+[MISC]
+212121	 //Message text
+d4d4d4	 //Message background
+404080	 //Patched bytes
+0080ff	 //Unsaved changes

--- a/src/ThemeSelector.cpp
+++ b/src/ThemeSelector.cpp
@@ -44,6 +44,7 @@ ThemeSelector::ThemeSelector(QWidget *parent)
     connect(m_widgets.lwSkinSelection, SIGNAL(itemSelectionChanged()), SLOT(themeSelected()));
     connect(m_widgets.btnObjectInspector, SIGNAL(clicked()), 
         &Core::instance(), SLOT(openObjectInspector()));
+    connect(m_widgets.leClrPathVal, SIGNAL(selectionChanged()), this, SLOT(clrPathSelectionChanged()));
     refresh();
 }
 
@@ -79,6 +80,16 @@ void ThemeSelector::refresh()
     m_curThemeList = std::move(themes);
 }
 
+void ThemeSelector::clrPathSelectionChanged()
+{
+    if(!settingSelection)
+    {
+        settingSelection = true;
+        m_widgets.leClrPathVal->selectAll();
+        settingSelection = false;
+    }
+}
+
 void ThemeSelector::themeSelected()
 {
     Q_ASSERT(m_curThemeList);
@@ -91,6 +102,11 @@ void ThemeSelector::themeSelected()
     m_widgets.lblAuthorVal->setText(entry.second->themeAuthor());
     m_widgets.lblVersionVal->setText(entry.second->themeVersion());
     m_widgets.lblNotesVal->setText(entry.second->themeNotes());
+
+    // Find first CLR file in theme dir
+    auto clrFiles = entry.first.entryList(QStringList()<<"*.clr", QDir::Files);
+    m_widgets.leClrPathVal->setText(clrFiles.begin() != clrFiles.end() ? QDir::toNativeSeparators(entry.first.absolutePath() + "/" + *clrFiles.begin()) : "");
+    m_widgets.leClrPathVal->selectAll();
 
     if (!entry.second->themePreviewImage().isEmpty())
     {

--- a/src/ThemeSelector.hpp
+++ b/src/ThemeSelector.hpp
@@ -44,6 +44,7 @@ class ThemeSelector : public QDialog
     Ui::ThemeSelector m_widgets;
     std::unique_ptr<ThemeList> m_curThemeList;
     QPixmap m_curPreviewImage;
+    bool settingSelection;
 public:
     /**
      * @brief   Constructor.
@@ -64,6 +65,10 @@ protected slots:
      * @brief   Slot emitted when a theme was selected.
      */
     void themeSelected();
+    /**
+     * @brief   Reselects CLR path if unselected.
+     */
+    void clrPathSelectionChanged();
 public slots:
     void resizeEvent(QResizeEvent *event) override;
 private:

--- a/ui/ThemeSelector.ui
+++ b/ui/ThemeSelector.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>528</width>
+    <width>612</width>
     <height>321</height>
    </rect>
   </property>
@@ -127,6 +127,36 @@
            </property>
            <property name="textFormat">
             <enum>Qt::RichText</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="lblClrPath">
+           <property name="text">
+            <string>CLR File:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLineEdit" name="leClrPathVal">
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="2">
+          <widget class="QLabel" name="lblInstallInstr">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Skins and text color themes (.clr) have to be applied seperately. If included, after choosing a skin copy the above path and go to Options -> Colors -> Import to apply color theme.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
...and install instructions. It finds the first .clr file in the skin's folder and shows it's path for easier installation.

<img src="https://user-images.githubusercontent.com/4965387/40185450-4bfa15ce-59fb-11e8-9025-bd22f20b193f.png" >

also included .clr files for current skins. Sources:

https://raw.githubusercontent.com/eugeii/ida-consonance/master/ida-consonance.clr
https://raw.githubusercontent.com/williballenthin/idawilli/master/themes/colors/adwaita-dark/adwaita-dark.clr
