### PR TITLE
Bug fix

### DIFF
--- a/plugins/idaskins/idafontconfig.py
+++ b/plugins/idaskins/idafontconfig.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-import os
+import os, sys
 
 import idaapi
 from PyQt5.QtGui import QFontDatabase
@@ -25,8 +25,10 @@ class IdaFontConfig(object):
             'Name',
             self._key,
             'Consolas'
-            if os.name == 'nt' else
-            QFontDatabase.systemFont(QFontDatabase.FixedFont).family()
+            if os.name == 'nt' else 
+            'Menlo'
+            if sys.platform == 'darwin' else
+            QFontDatabase.systemFont(QFontDatabase.FixedFont).family()    
         )
 
     @property


### PR DESCRIPTION
idaskins on IDA 7.0 on macos 10.13.4+ raised an error on reg_read_string for QFontDatabase.systemFont(QFontDatabase.FixedFont).family()

Returning a standard fixed font ie 'Menlo' or 'Monaco' fixes the issue.

Included the original call for linux