### PR TITLE
Idafontconfig: convert family from unicode to str

### DIFF
--- a/plugins/idaskins/idafontconfig.py
+++ b/plugins/idaskins/idafontconfig.py
@@ -26,7 +26,7 @@ class IdaFontConfig(object):
             self._key,
             'Consolas'
             if os.name == 'nt' else
-            QFontDatabase.systemFont(QFontDatabase.FixedFont).family()
+            QFontDatabase.systemFont(QFontDatabase.FixedFont).family().encode()
         )
 
     @property


### PR DESCRIPTION
On Linux, the Qt API returns a unicode object instead of str, which causes reg_read_string to TypeError