### PR TITLE
Fix broken english in intial startup string

### DIFF
--- a/plugins/idaskins/plugin.py
+++ b/plugins/idaskins/plugin.py
@@ -62,8 +62,8 @@ class IdaSkinsPlugin(QObject, idaapi.plugin_t):
             selection = QMessageBox.information(
                 qApp.activeWindow(),
                 "IDASkins: First start",
-                "IDASkins detected that this is you first IDA startup with "
-                "this plugin installed. Do you wish to select a theme now?",
+                "IDASkins has detected that this is the first time you've started IDA with "
+                "the plugin installed. Select a theme now?",
                 QMessageBox.Yes | QMessageBox.No,
             )
 


### PR DESCRIPTION
The window that appears on first plugin launch doesn't make sense. I've rewritten it to sound better.